### PR TITLE
HTML-centric HATEOAS state management

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,38 +2,41 @@
 <html>
   <head><title>Grecha.js</title></head>
   <body>
+
+    <input id="count" type="hidden" value="0"></input>
+    <input id="hard" type="hidden" value="false"></input>
+
     <div id="entry"></div>
     <script src="./grecha.js"></script>
     <script>
       const kasha = img("Kasha.png");
       const kashaHard = img("KashaHard.gif");
       
-      let count = 0;
-      let hard = false;
-      const r = router({
-        "/": () => div(
-          h1("Grecha.js"),
-          div(a("Foo").att$("href", "#/foo")),
-          div(a("Bar").att$("href", "#/bar")),
-          div("Counter: "+count),
-          div(hard ? kashaHard : kasha).onclick$(function () {
-            count += 1;
-            hard = !hard
-            r.refresh();
-          }),
-        ),
-        "/foo": () => div(
-          h1("Foo"),
-          p(LOREM),
-          div(a("Home").att$("href", "#")),
-        ),
-        "/bar": () => div(
-          h1("Bar"),
-          p(LOREM),
-          div(a("Home").att$("href", "#"))
-        )
-      });
-      entry.appendChild(r);
+      entry.appendChild(router(
+        {
+          "/": () => div(
+            h1("Grecha.js"),
+            div(a("Foo").att$("href", "#/foo")),
+            div(a("Bar").att$("href", "#/bar")),
+            div("Counter: "+window.count.value),
+            div(window.hard.value=='true' ? kashaHard : kasha).onclick$(function () {
+              window.count.value = Number(window.count.value) + 1;
+              window.hard.value = !(window.hard.value=='true');
+            }),
+          ),
+          "/foo": () => div(
+            h1("Foo"),
+            p(LOREM),
+            div(a("Home").att$("href", "#")),
+          ),
+          "/bar": () => div(
+            h1("Bar"),
+            p(LOREM),
+            div(a("Home").att$("href", "#"))
+          )
+        },
+        [window.count, window.hard]
+      ));
     </script>
   </body>
 </html>

--- a/grecha.js
+++ b/grecha.js
@@ -36,10 +36,10 @@ function input(type) {
     return tag("input").att$("type", type);
 }
 
-function router(routes) {
+function router(routes, stateData) {
     let result = div();
 
-    function syncHash() {
+    result.refresh = ()=>{
         let hashLocation = document.location.hash.split('#')[1];
         if (!hashLocation) {
             hashLocation = '/';
@@ -55,10 +55,10 @@ function router(routes) {
         result.replaceChildren(routes[hashLocation]());
         return result;
     };
-    syncHash();
+    result.refresh();
     // TODO(#3): there is way to "destroy" an instance of the router to make it remove it's "hashchange" callback
-    window.addEventListener("hashchange", syncHash);
-    result.refresh = syncHash;
-
+    window.addEventListener("hashchange", result.refresh);
+    result.observer = new MutationObserver(result.refresh);
+    stateData?.forEach(e => result.observer.observe(e,{childList: true,subtree: true,attributes:true}));
     return result;
 }


### PR DESCRIPTION
Restores router init to something closer to the look and feel of the original https://github.com/tsoding/grecha.js/blob/cf81410ed94d660cbc852df90e9e1b02aa17a764/example.html

Follows https://htmx.org/essays/hateoas/ principles, keeping application state in HTML instead of JS variables.
This encourages you to inline the data directly from the backend instead of the multitude of JSON APIs as is the vogue. Also avoids hiding application state out in some arbitrary \<script\> or .js file, which is liable to be overlooked.
The `stateData` can also be structured XML-like tags, and subtree changes will also trigger refresh.

This allows you to easily see what's going on straight from browser dev tools without relying on `console.log` everywhere
![image](https://github.com/tsoding/grecha.js/assets/150465372/99055b21-9d6a-43c2-b3a6-6936c019fdf6)

Values flash momentarily during change
![image](https://github.com/tsoding/grecha.js/assets/150465372/251222bf-f9fd-466d-b977-6d6d8b95c77d)

Downside is that you may have to parse the value before actually using it, but that's basic JS.

Previous `r.refresh()` style of application state management is still available if desired, and line number of grecha.js maintained.