### PR TITLE
Bring grecha.js back to it's glory days

### DIFF
--- a/grecha.js
+++ b/grecha.js
@@ -48,16 +48,21 @@ function router(routes) {
         if (!(hashLocation in routes)) {
             // TODO(#2): make the route404 customizable in the router component
             const route404 = '/404';
+
             console.assert(route404 in routes);
             hashLocation = route404;
         }
 
         result.replaceChildren(routes[hashLocation]());
+
         return result;
     };
+
     syncHash();
+
     // TODO(#3): there is way to "destroy" an instance of the router to make it remove it's "hashchange" callback
     window.addEventListener("hashchange", syncHash);
+
     result.refresh = syncHash;
 
     return result;


### PR DESCRIPTION
It came to my attention that recent changes in the codebase broke one of the [design principles](https://youtu.be/XAGCULPO_DE?t=4696) of grecha.js, which is always maintaining 69 lines of code.

Through deeply complex refactoring techniques I was able to bring the framework back to it's rightful path. You're welcome.
